### PR TITLE
Ordering and translation of checkboxes + radio values

### DIFF
--- a/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
+++ b/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
@@ -73,7 +73,7 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
       elsif field[:field_type] == 'captcha'
         values[label] << '--'
       elsif field[:field_type] == 'radio' || field[:field_type] == 'checkboxes'
-        values[label] << fields[cid].join(',') if fields[cid].present?
+        values[label] << fields[cid].map { |f| f.to_s.translate }.join(', ') if fields[cid].present?
       else
         values[label] << fields[cid] if fields[cid].present?
       end

--- a/app/controllers/plugins/cama_contact_form/admin_forms_controller.rb
+++ b/app/controllers/plugins/cama_contact_form/admin_forms_controller.rb
@@ -49,7 +49,7 @@ class Plugins::CamaContactForm::AdminFormsController < CamaleonCms::Apps::Plugin
     add_breadcrumb I18n.t("plugins.cama_contact_form.list_responses", default: 'Contact form records')
     @form = current_site.contact_forms.where({id: params[:admin_form_id]}).first
     values = JSON.parse(@form.value).to_sym
-    @op_fields = values[:fields]
+    @op_fields = values[:fields].select{ |field| relevant_field? field }
     @forms = current_site.contact_forms.where({parent_id: @form.id})
     @forms = @forms.paginate(:page => params[:page], :per_page => current_site.admin_per_page)
   end
@@ -71,5 +71,9 @@ class Plugins::CamaContactForm::AdminFormsController < CamaleonCms::Apps::Plugin
       flash[:error] = "Error form class"
       redirect_to cama_admin_path
     end
+  end
+
+  def relevant_field?(field)
+    !%w(captcha submit button).include? field[:field_type]
   end
 end

--- a/app/models/plugins/cama_contact_form/cama_contact_form.rb
+++ b/app/models/plugins/cama_contact_form/cama_contact_form.rb
@@ -10,6 +10,8 @@ class Plugins::CamaContactForm::CamaContactForm < ActiveRecord::Base
   before_validation :before_validating
   before_create :fix_save_settings
 
+  default_scope { order(created_at: :desc) }
+
   # [{"label":"Untitled","field_type":"text","required":true,"field_options":{"size":"large","field_class":"Default"},"cid":"c2"},{"label":"Untitled","field_type":"paragraph","required":true,"field_options":{"size":"large","field_class":"Default"},"cid":"c6"},{"label":"Untitled","field_type":"captcha","required":true,"field_options":{"field_class":"Default"},"cid":"c10"},{"label":"Untitled","field_type":"checkboxes","required":true,"field_options":{"options":[{"label":"Default","checked":false},{"label":"Default","checked":false}],"field_class":"Default","description":"description\n"},"cid":"c12"}]
   def fields
     @_the_fields ||= JSON.parse(self.value || '{fields: []}').with_indifferent_access

--- a/app/views/plugins/cama_contact_form/admin_forms/responses.html.erb
+++ b/app/views/plugins/cama_contact_form/admin_forms/responses.html.erb
@@ -33,7 +33,7 @@
                     <% if default[:field_type] == "file" %>
                         <td><%= link_to(value[:fields][cid], value[:fields][cid]) %></td>
                     <% elsif default[:field_type] == "radio" || default[:field_type] == "checkboxes" %>
-                        <td><%= value[:fields][cid].map(&:inspect).join(', ') if value[:fields][cid].present? %></td>
+                        <td><%= value[:fields][cid].map { |f| f.to_s.translate }.join(', ') if value[:fields][cid].present? %></td>
                     <% else %>
                         <td><%= value[:fields][cid] %></td>
                     <% end %>


### PR DESCRIPTION
Hey this PR solves some problems I encountered:

* The responses list is not ordered by date. This is a bit confusing.
* The reponses list shows buttons, submits and captchas which do not have values anyway.
* Checkbox and radio input values are not translated. Same issue as https://github.com/owen2345/cama_contact_form/issues/5