### PR TITLE
add required attr to html if required is defined and true

### DIFF
--- a/app/helpers/plugins/cama_contact_form/main_helper.rb
+++ b/app/helpers/plugins/cama_contact_form/main_helper.rb
@@ -82,6 +82,7 @@ module Plugins::CamaContactForm::MainHelper
       ob = r[:field]
       ob[:custom_class] = r[:custom_class]
       ob[:custom_attrs] = r[:custom_attrs]
+      ob[:custom_attrs][:required] = 'true' if ob[:required].present? && ob[:required].to_bool
       field_options = ob[:field_options]
       for_name = ob[:label].to_s
       f_name = "fields[#{ob[:cid]}]"


### PR DESCRIPTION
Hey @owen2345 
I know it's possible to do this via a hook but I think it's good practice to add the required attribute to the form elements. Also that way the forms are not submitted as long as required values are missing (client site validation).