### PR TITLE
Label Translation + omission irrelevant fields in mail

### DIFF
--- a/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
+++ b/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
@@ -64,20 +64,23 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
   def convert_form_values(form, fields)
     values = {}
     form.fields.each do |field|
+      next unless relevant_field?(field)
+      ft = field[:field_type]
       cid = field[:cid].to_sym
       label = values.keys.include?(field[:label]) ? "#{field[:label]} (#{cid})" : field[:label].to_s.translate
       values[label] = []
-      if field[:field_type] == 'submit' || field[:field_type] == 'button'
-      elsif field[:field_type] == 'file'
+      if ft == 'file'
         values[label] << fields[cid].split('/').last if fields[cid].present?
-      elsif field[:field_type] == 'captcha'
-        values[label] << (params[:captcha] rescue '')
-      elsif field[:field_type] == 'radio' || field[:field_type] == 'checkboxes'
+      elsif ft == 'radio' || ft == 'checkboxes'
         values[label] << fields[cid].map { |f| f.to_s.translate }.join(', ') if fields[cid].present?
       else
         values[label] << fields[cid] if fields[cid].present?
       end
     end
-    return values
+    values
+  end
+
+  def relevant_field?(field)
+    !%w(captcha submit button).include? field[:field_type]
   end
 end

--- a/app/controllers/plugins/cama_contact_form/admin_forms_controller.rb
+++ b/app/controllers/plugins/cama_contact_form/admin_forms_controller.rb
@@ -1,5 +1,6 @@
 class Plugins::CamaContactForm::AdminFormsController < CamaleonCms::Apps::PluginsAdminController
   include Plugins::CamaContactForm::MainHelper
+  include Plugins::CamaContactForm::ContactFormControllerConcern
   before_action :set_form, only: ['show','edit','update','destroy']
   add_breadcrumb I18n.t("plugins.cama_contact_form.title", default: 'Contact Form'), :admin_plugins_cama_contact_form_admin_forms_path
 
@@ -71,9 +72,5 @@ class Plugins::CamaContactForm::AdminFormsController < CamaleonCms::Apps::Plugin
       flash[:error] = "Error form class"
       redirect_to cama_admin_path
     end
-  end
-
-  def relevant_field?(field)
-    !%w(captcha submit button).include? field[:field_type]
   end
 end

--- a/app/helpers/plugins/cama_contact_form/main_helper.rb
+++ b/app/helpers/plugins/cama_contact_form/main_helper.rb
@@ -139,15 +139,16 @@ module Plugins::CamaContactForm::MainHelper
     end
 
     options.each do |op|
+      label = op[:label].translate
       if type == "radio" || type == "checkbox"
         html += "<div class=\"#{type} #{ob[:custom_class]}\">
                     <label for=\"#{ob[:cid]}\">
-                      <input #{ob[:custom_attrs].to_attr_format} type=\"#{type}\" #{'checked' if op[:checked].to_s.cama_true?} name=\"#{f_name}[]\" class=\"\" value=\"#{op[:label].downcase}\">
-                      #{op[:label]}
+                      <input #{ob[:custom_attrs].to_attr_format} type=\"#{type}\" #{'checked' if op[:checked].to_s.cama_true?} name=\"#{f_name}[]\" class=\"\" value=\"#{label.downcase}\">
+                      #{label}
                     </label>
                   </div>"
       else
-        html += "<option  value=\"#{op[:label].downcase.gsub(" ", "_")}\" #{"selected" if "#{op[:label].downcase.gsub(" ", "_")}" == values[cid] || op[:checked].to_s.cama_true? } >#{op[:label]}</option>"
+        html += "<option  value=\"#{label.downcase.gsub(" ", "_")}\" #{"selected" if "#{label.downcase.gsub(" ", "_")}" == values[cid] || op[:checked].to_s.cama_true? } >#{label}</option>"
       end
     end
 


### PR DESCRIPTION
Hola,

I should have made two PR's out of this, but I guess it's quite clear what's going on anyway.

- I use `relevant_field?` method (just moved it to the Concern) to filter out fields that should not be shown in the email markup. Is there any specific reason why `captcha` fields are added in `convert_form_values`?
- In `main_helper.rb` some labels were actually not translated.