### PR TITLE
Allow multiple files to be uploaded 

### DIFF
--- a/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
+++ b/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
@@ -11,7 +11,7 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
               errors << res[:error].to_s.translate
             else
               attachments << res[:file_path]
-              file_paths << res[:file_path].sub(Rails.public_path.to_s, cama_root_url)
+              file_paths << to_public_path(res[:file_path])
             end
           end
           fields[f[:cid].to_sym] = file_paths
@@ -87,5 +87,13 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
 
   def relevant_field?(field)
     !%w(captcha submit button).include? field[:field_type]
+  end
+
+  def to_public_path(file_path)
+    file_path.sub(Rails.public_path.to_s, cama_root_url)
+  end
+
+  def to_local_path(file_path)
+    file_path.sub(cama_root_url, Rails.public_path.to_s)
   end
 end

--- a/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
+++ b/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
@@ -4,13 +4,17 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
     if validate_to_save_form(form, fields, errors)
       form.fields.each do |f|
         if f[:field_type] == 'file'
-          res = cama_tmp_upload(fields[f[:cid].to_sym], {maximum: 5.megabytes, path: Rails.public_path.join("contact_form", current_site.id.to_s)})
-          if res[:error].present?
-            errors << res[:error].to_s.translate
-          else
-            attachments << res[:file_path]
-            fields[f[:cid].to_sym] = res[:file_path].sub(Rails.public_path.to_s, cama_root_url)
+          file_paths = []
+          fields[f[:cid].to_sym].each do |file|
+            res = cama_tmp_upload(file, {maximum: 5.megabytes, path: Rails.public_path.join("contact_form", current_site.id.to_s)})
+            if res[:error].present?
+              errors << res[:error].to_s.translate
+            else
+              attachments << res[:file_path]
+              file_paths << res[:file_path].sub(Rails.public_path.to_s, cama_root_url)
+            end
           end
+          fields[f[:cid].to_sym] = file_paths
         end
       end
       new_settings = {"fields" => fields, "created_at" => Time.current.strftime("%Y-%m-%d %H:%M:%S").to_s}.to_json
@@ -27,7 +31,7 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
           cama_send_email(answer_to, form.the_settings[:railscf_mail][:subject_answer].to_s.translate.cama_replace_codes(fields), {content: content})
         end
       else
-        errors << form.the_message('mail_sent_ng', t('.error_form_val', default: 'Occurred an error, please try again.'))
+        errors << form.the_message('mail_sent_ng', t('.error_form_val', default: 'An error occurred, please try again.'))
       end
     end
   end
@@ -44,8 +48,8 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
             errors << "#{label.to_s.translate}: #{form.the_message('invalid_required', t('.error_validation_val', default: 'This value is required'))}"
             validate = false
           end
-          if f[:field_type].to_s == "email"
-            if !fields[cid].match(/@/)
+          if f[:field_type].to_s == 'email'
+            unless fields[cid].match(/@/)
               errors << "#{label.to_s.translate}: #{form.the_message('invalid_email', t('.email_invalid_val', default: 'The e-mail address appears invalid'))}"
               validate = false
             end
@@ -70,7 +74,8 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
       label = values.keys.include?(field[:label]) ? "#{field[:label]} (#{cid})" : field[:label].to_s.translate
       values[label] = []
       if ft == 'file'
-        values[label] << fields[cid].split('/').last if fields[cid].present?
+        nr_files = fields[cid].size
+        values[label] << "#{nr_files} #{"file".pluralize(nr_files)} (attached)" if fields[cid].present?
       elsif ft == 'radio' || ft == 'checkboxes'
         values[label] << fields[cid].map { |f| f.to_s.translate }.join(', ') if fields[cid].present?
       else

--- a/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
+++ b/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
@@ -6,7 +6,12 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
         if f[:field_type] == 'file'
           file_paths = []
           fields[f[:cid].to_sym].each do |file|
-            res = cama_tmp_upload(file, {maximum: 5.megabytes, path: Rails.public_path.join("contact_form", current_site.id.to_s)})
+            res = cama_tmp_upload(file, {
+                maximum: current_site.get_option('filesystem_max_size', 100).megabytes,
+                path: Rails.public_path.join("contact_form", current_site.id.to_s),
+                name: file.original_filename
+              }
+            )
             if res[:error].present?
               errors << res[:error].to_s.translate
             else

--- a/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
+++ b/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
@@ -16,7 +16,7 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
               errors << res[:error].to_s.translate
             else
               attachments << res[:file_path]
-              file_paths << to_public_path(res[:file_path])
+              file_paths << res[:file_path].sub(Rails.public_path.to_s, cama_root_url)
             end
           end
           fields[f[:cid].to_sym] = file_paths
@@ -92,13 +92,5 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
 
   def relevant_field?(field)
     !%w(captcha submit button).include? field[:field_type]
-  end
-
-  def to_public_path(file_path)
-    file_path.sub(Rails.public_path.to_s, cama_root_url)
-  end
-
-  def to_local_path(file_path)
-    file_path.sub(cama_root_url, Rails.public_path.to_s)
   end
 end

--- a/app/controllers/plugins/cama_contact_form/admin_forms_controller.rb
+++ b/app/controllers/plugins/cama_contact_form/admin_forms_controller.rb
@@ -57,23 +57,8 @@ class Plugins::CamaContactForm::AdminFormsController < CamaleonCms::Apps::Plugin
 
   def del_response
     response = current_site.contact_forms.find_by_id(params[:response_id])
-    if response.present?
-      response_data = response.the_settings
-      if response.destroy
-        # Delete files if any
-        form = current_site.contact_forms.find_by_id(response.parent_id)
-        file_cids = form.fields
-                        .select { |f| f[:field_type] == 'file' }
-                        .map { |f| f[:cid].to_sym }
-        file_cids.each { |cid|
-          # Flatten because of backwards compatibility (file could be a string or an array)
-          [response_data[:fields][cid]].flatten.each { |file|
-            file = to_local_path(file)
-            File.delete file if File.exists? file
-          }
-        }
-        flash[:notice] = "#{t('.actions.msg_deleted', default: 'The response has been deleted')}"
-      end
+    if response.present? && response.destroy
+      flash[:notice] = "#{t('.actions.msg_deleted', default: 'The response has been deleted')}"
     end
     redirect_to action: :responses
   end

--- a/app/controllers/plugins/cama_contact_form/admin_forms_controller.rb
+++ b/app/controllers/plugins/cama_contact_form/admin_forms_controller.rb
@@ -57,8 +57,23 @@ class Plugins::CamaContactForm::AdminFormsController < CamaleonCms::Apps::Plugin
 
   def del_response
     response = current_site.contact_forms.find_by_id(params[:response_id])
-    if response.present? && response.destroy
-      flash[:notice] = "#{t('.actions.msg_deleted', default: 'The response has been deleted')}"
+    if response.present?
+      response_data = response.the_settings
+      if response.destroy
+        # Delete files if any
+        form = current_site.contact_forms.find_by_id(response.parent_id)
+        file_cids = form.fields
+                        .select { |f| f[:field_type] == 'file' }
+                        .map { |f| f[:cid].to_sym }
+        file_cids.each { |cid|
+          # Flatten because of backwards compatibility (file could be a string or an array)
+          [response_data[:fields][cid]].flatten.each { |file|
+            file = to_local_path(file)
+            File.delete file if File.exists? file
+          }
+        }
+        flash[:notice] = "#{t('.actions.msg_deleted', default: 'The response has been deleted')}"
+      end
     end
     redirect_to action: :responses
   end

--- a/app/helpers/plugins/cama_contact_form/main_helper.rb
+++ b/app/helpers/plugins/cama_contact_form/main_helper.rb
@@ -111,7 +111,7 @@ module Plugins::CamaContactForm::MainHelper
         when 'captcha'
           temp2 = cama_captcha_tag(5, {}, {class: "#{ob[:custom_class].presence || 'form-control'} field-captcha required"}.merge(ob[:custom_attrs]))
         when 'file'
-          temp2 = "<input multiple=\"multiple\" type=\"file\" value=\"\" name=\"#{f_name}\" #{ob[:custom_attrs].to_attr_format} class=\"#{ob[:custom_class].presence || 'form-control'}\">"
+          temp2 = "<input multiple=\"multiple\" type=\"file\" value=\"\" name=\"#{f_name}[]\" #{ob[:custom_attrs].to_attr_format} class=\"#{ob[:custom_class].presence || 'form-control'}\">"
         when 'dropdown'
           temp2 = cama_form_select_multiple_bootstrap(ob, ob[:label], "select",values)
         else

--- a/app/models/plugins/cama_contact_form/cama_contact_form.rb
+++ b/app/models/plugins/cama_contact_form/cama_contact_form.rb
@@ -48,15 +48,14 @@ class Plugins::CamaContactForm::CamaContactForm < ActiveRecord::Base
   def delete_uploaded_files
     return if self.parent_id.nil?
     form = self.class.find_by_id self.parent_id
+    response_data = the_settings[:fields]
     file_cids = form.fields
                     .select { |f| f[:field_type] == 'file' }
                     .map { |f| f[:cid].to_sym }
-    file_cids.each { |cid|
-      # Flatten because of backwards compatibility (file could be a string or an array)
-      [the_settings[:fields][cid]].flatten.each { |file|
-        file = file.sub(Rails.application.routes.url_helpers.cama_root_url, Rails.public_path.to_s)
-        File.delete file if File.exists? file
-      }
-    }
+
+    file_cids
+        .flat_map { |cid| response_data[cid] }
+        .map { |file| file.sub Rails.application.routes.url_helpers.cama_root_url, Rails.public_path.to_s }
+        .each { |file| File.delete file if File.exists? file }
   end
 end

--- a/app/models/plugins/cama_contact_form/cama_contact_form.rb
+++ b/app/models/plugins/cama_contact_form/cama_contact_form.rb
@@ -1,4 +1,5 @@
 class Plugins::CamaContactForm::CamaContactForm < ActiveRecord::Base
+  include Plugins::CamaContactForm::MainHelper
   self.table_name = 'plugins_contact_forms'
   belongs_to :site, class_name: "CamaleonCms::Site"
   # attr_accessible :site_id, :name, :description, :count, :slug, :value, :settings, :parent_id
@@ -9,6 +10,7 @@ class Plugins::CamaContactForm::CamaContactForm < ActiveRecord::Base
 
   before_validation :before_validating
   before_create :fix_save_settings
+  before_destroy :delete_uploaded_files
 
   default_scope { order(created_at: :desc) }
 
@@ -41,5 +43,20 @@ class Plugins::CamaContactForm::CamaContactForm < ActiveRecord::Base
   def fix_save_settings
     self.value = {"fields" => []}.to_json unless self.value.present?
     self.settings = {}.to_json unless self.settings.present?
+  end
+
+  def delete_uploaded_files
+    return if self.parent_id.nil?
+    form = self.class.find_by_id self.parent_id
+    file_cids = form.fields
+                    .select { |f| f[:field_type] == 'file' }
+                    .map { |f| f[:cid].to_sym }
+    file_cids.each { |cid|
+      # Flatten because of backwards compatibility (file could be a string or an array)
+      [the_settings[:fields][cid]].flatten.each { |file|
+        file = file.sub(Rails.application.routes.url_helpers.cama_root_url, Rails.public_path.to_s)
+        File.delete file if File.exists? file
+      }
+    }
   end
 end

--- a/app/views/plugins/cama_contact_form/admin_forms/responses.html.erb
+++ b/app/views/plugins/cama_contact_form/admin_forms/responses.html.erb
@@ -32,7 +32,12 @@
                 <% @op_fields.each do |default| %>
                     <% cid = default[:cid].to_sym %>
                     <% if default[:field_type] == "file" %>
-                        <td><%= link_to(value[:fields][cid], value[:fields][cid]) %></td>
+                        <td>
+                        <%# flatten is necessary for backwards compatibility: ["file"].flatten == [["file]].flatten %>
+                        <% [value[:fields][cid]].flatten.each do |file| %>
+                            <%= link_to file.split('/').last, file %><br>
+                        <% end %>
+                        </td>
                     <% elsif default[:field_type] == "radio" || default[:field_type] == "checkboxes" %>
                         <td><%= value[:fields][cid].map { |f| f.to_s.translate }.join(', ') if value[:fields][cid].present? %></td>
                     <% else %>

--- a/app/views/plugins/cama_contact_form/admin_forms/responses.html.erb
+++ b/app/views/plugins/cama_contact_form/admin_forms/responses.html.erb
@@ -35,7 +35,7 @@
                         <td>
                         <%# flatten is necessary for backwards compatibility: ["file"].flatten == [["file]].flatten %>
                         <% [value[:fields][cid]].flatten.each do |file| %>
-                            <%= link_to file.split('/').last, file %><br>
+                            <%= link_to file.split('/').last, file, target: '_blank' %><br>
                         <% end %>
                         </td>
                     <% elsif default[:field_type] == "radio" || default[:field_type] == "checkboxes" %>


### PR DESCRIPTION
Hey @owen2345,

multiple file upload did not work. This fixes it plus keeps original filenames and deletes all files belonging to a response when response it deleted.