### PR TITLE
fix: submitting gives error when optional file field is left empty

### DIFF
--- a/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
+++ b/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
@@ -5,7 +5,7 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
       form.fields.each do |f|
         if f[:field_type] == 'file'
           file_paths = []
-          fields[f[:cid].to_sym].each do |file|
+          fields[f[:cid].to_sym].to_a.each do |file|
             res = cama_tmp_upload(file, {
                 maximum: current_site.get_option('filesystem_max_size', 100).megabytes,
                 path: Rails.public_path.join("contact_form", current_site.id.to_s),
@@ -64,7 +64,7 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
             errors << "#{label.to_s.translate}: #{form.the_message('captcha_not_match', t('.captch_error_val', default: 'The entered code is incorrect'))}"
             validate = false
           }
-            
+
           if form.recaptcha_enabled?
             form.set_captcha_settings!
             error_message.call unless verify_recaptcha


### PR DESCRIPTION
Create a form with an optional file field and a submit button. Fill out the form, submit and see the error.

Cause: `fields[f[:cid].to_sym]` returns `nil`. => undefined method `each' for
nil:NilClass. 

Solution: force it to be an array with [`NilClass#to_a`](https://ruby-doc.org/core-2.6.1/NilClass.html#method-i-to_a).