### PR TITLE
Fix: Update recaptcha gem to  5.0

### DIFF
--- a/app/helpers/plugins/cama_contact_form/main_helper.rb
+++ b/app/helpers/plugins/cama_contact_form/main_helper.rb
@@ -1,5 +1,5 @@
 module Plugins::CamaContactForm::MainHelper
-  include Recaptcha::ClientHelper
+  include Recaptcha::Adapters::ViewMethods
   def self.included(klass)
     klass.helper_method [:cama_form_element_bootstrap_object, :cama_form_shortcode] rescue "" # here your methods accessible from views
   end

--- a/cama_contact_form.gemspec
+++ b/cama_contact_form.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails"
-  s.add_dependency "recaptcha"
+  s.add_dependency "recaptcha", ">= 5.0"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Issue: <NameError: uninitialized constant Recaptcha::ClientHelper>

Recaptcha renamed helper class `Recaptcha::ClientHelper` to `Recaptcha::Adapters::ViewMethods`

https://github.com/ambethia/recaptcha/commit/43a928358c99a4f64a2654f03d7181ba3c585b3d#diff-4ac32a78649ca5bdd8e0ba38b7006a1e

This commit also will fix this issue:

https://github.com/owen2345/camaleon-cms/issues/901