### PR TITLE
Fix format for rails 7

### DIFF
--- a/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
+++ b/app/controllers/concerns/plugins/cama_contact_form/contact_form_controller_concern.rb
@@ -27,7 +27,7 @@ module Plugins::CamaContactForm::ContactFormControllerConcern
       if form_new.save
         fields_data = convert_form_values(form, fields)
         message_body = form.the_settings[:railscf_mail][:body].to_s.translate.cama_replace_codes(fields)
-        content = render_to_string(partial: plugin_view('contact_form/email_content'), layout: false, formats: ['html'], locals: {file_attachments: attachments, fields: fields_data, values: fields, message_body: message_body, form: form})
+        content = render_to_string(partial: plugin_view('contact_form/email_content'), layout: false, formats: [:html], locals: {file_attachments: attachments, fields: fields_data, values: fields, message_body: message_body, form: form})
         cama_send_email(form.the_settings[:railscf_mail][:to], form.the_settings[:railscf_mail][:subject].to_s.translate.cama_replace_codes(fields), {attachments: attachments, content: content, extra_data: {fields: fields_data}})
         success << form.the_message('mail_sent_ok', t('.success_form_val', default: 'Your message has been sent successfully. Thank you very much!'))
         args = {form: form, values: fields}; hooks_run("contact_form_after_submit", args)


### PR DESCRIPTION
Rails 7 is strict on format to use find template. With the current code we have an error 'missing template'.

For those who want a workaround, override the changed file here in your camaleon repository directly while it's fixed.